### PR TITLE
Fix work and share buttons on archive page

### DIFF
--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -135,17 +135,40 @@
                 📦 Archive
               </div>
               <div class="section-actions">
+                <AppButton size="sm" variant="secondary" @click="showFilters = !showFilters">
+                  Filter
+                </AppButton>
+                <AppButton size="sm" variant="secondary" @click="showSort = !showSort">
+                  Sort
+                </AppButton>
                 <AppButton size="sm" variant="secondary">
                   Export
                 </AppButton>
               </div>
             </div>
+            
+            <!-- Filter Panel -->
+            <FilterPanel v-if="showFilters" />
+            
+            <!-- Sort Panel -->
+            <SortPanel 
+              v-if="showSort" 
+              :current-sort="currentSort"
+              @sort-change="setSortOrder"
+            />
+            
             <div class="section-content">
               <BookmarkList
                 :bookmarks="filteredBookmarks"
                 :batch-mode="batchMode"
+                :total-count="totalBookmarksForCurrentTab"
+                :show-results-count="hasActiveFilters"
+                :loading="loading"
                 @toggle-selection="toggleSelection"
                 @edit="handleEdit"
+                @move-to-working="handleMoveToWorking"
+                @move-to-share="handleShareSingle"
+                @archive="(id) => moveBookmarks([id], 'archived')"
               />
             </div>
           </div>


### PR DESCRIPTION
- Add missing @move-to-working event handler to invoke MoveToProjectModal
- Add missing @move-to-share event handler to invoke ShareBookmarkModal
- Add filter and sort functionality to archive tab for consistency
- Archive page now has full functionality parity with other tabs
- Users can move archived bookmarks back to working projects or share them
- Maintains existing modal workflows and notification system integration

🤖 Generated with [Claude Code](https://claude.ai/code)