### PR TITLE
Replace mock domains with actual latest bookmark URLs in project cards

### DIFF
--- a/frontend/src/components/project/ProjectList.vue
+++ b/frontend/src/components/project/ProjectList.vue
@@ -82,8 +82,8 @@
           <div class="bookmark-item">
             <div class="bookmark-favicon">📖</div>
             <div class="bookmark-content">
-              <div class="bookmark-title">{{ getSampleBookmarkTitle(project.topic) }}</div>
-              <div class="bookmark-domain">{{ getSampleDomain(project.topic) }}</div>
+              <div class="bookmark-title">{{ project.latestTitle || getSampleBookmarkTitle(project.topic) }}</div>
+              <div class="bookmark-domain">{{ getActualDomain(project) }}</div>
               <div class="bookmark-tags">
                 <span class="bookmark-tag">{{ project.status }}</span>
                 <span class="bookmark-tag">{{ project.topic.toLowerCase() }}</span>
@@ -221,6 +221,21 @@ const getSampleDomain = (topic: string): string => {
   
   const key = Object.keys(domains).find(k => topic.includes(k))
   return key ? domains[key] : 'docs.example.com'
+}
+
+const getActualDomain = (project: ProjectStat): string => {
+  // Use real URL if available
+  if (project.latestURL) {
+    try {
+      const url = new URL(project.latestURL)
+      return url.hostname
+    } catch (e) {
+      // Fallback to sample domain if URL parsing fails
+      return getSampleDomain(project.topic)
+    }
+  }
+  // Fallback to sample domain if no URL available
+  return getSampleDomain(project.topic)
 }
 
 const formatDate = (dateString: string) => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -65,6 +65,8 @@ export interface ProjectStat {
   count: number
   lastUpdated: string
   status: 'active' | 'stale' | 'inactive'
+  latestURL?: string
+  latestTitle?: string
 }
 
 export type TabType = 'triage' | 'projects' | 'share' | 'archive'

--- a/main_test.go
+++ b/main_test.go
@@ -750,6 +750,38 @@ func TestGetStatsSummary(t *testing.T) {
 		if len(stats.ProjectStats) == 0 {
 			t.Error("Expected project stats, got none")
 		}
+		
+		// Test the new latest resource functionality
+		for _, project := range stats.ProjectStats {
+			if project.LatestURL == "" {
+				t.Errorf("Expected latestURL for project %s, got empty string", project.Topic)
+			}
+			if project.LatestTitle == "" {
+				t.Errorf("Expected latestTitle for project %s, got empty string", project.Topic)
+			}
+			
+			// Validate specific projects based on test data
+			switch project.Topic {
+			case "Programming":
+				if project.Count != 2 {
+					t.Errorf("Expected Programming project to have 2 bookmarks, got %d", project.Count)
+				}
+				// Should contain the latest bookmark (either Example 2 or Example 5)
+				if project.LatestURL != "https://example.com/2" && project.LatestURL != "https://example.com/5" {
+					t.Errorf("Expected Programming project latest URL to be from test data, got %s", project.LatestURL)
+				}
+			case "Development":
+				if project.Count != 1 {
+					t.Errorf("Expected Development project to have 1 bookmark, got %d", project.Count)
+				}
+				if project.LatestURL != "https://example.com/4" {
+					t.Errorf("Expected Development project latest URL to be https://example.com/4, got %s", project.LatestURL)
+				}
+				if project.LatestTitle != "Example 4" {
+					t.Errorf("Expected Development project latest title to be 'Example 4', got %s", project.LatestTitle)
+				}
+			}
+		}
 	})
 }
 
@@ -936,6 +968,20 @@ func TestHandleStatsSummary_Success(t *testing.T) {
 		
 		if stats.ActiveProjects != 2 {
 			t.Errorf("Expected 2 active projects, got %d", stats.ActiveProjects)
+		}
+		
+		// Test the new latest resource functionality in HTTP response
+		if len(stats.ProjectStats) == 0 {
+			t.Error("Expected project stats in HTTP response, got none")
+		}
+		
+		for _, project := range stats.ProjectStats {
+			if project.LatestURL == "" {
+				t.Errorf("Expected latestURL for project %s in HTTP response, got empty string", project.Topic)
+			}
+			if project.LatestTitle == "" {
+				t.Errorf("Expected latestTitle for project %s in HTTP response, got empty string", project.Topic)
+			}
 		}
 	})
 }


### PR DESCRIPTION
- Add latestURL and latestTitle fields to ProjectStat struct and API responses
- Update getProjectStats SQL query to fetch real latest bookmark data per project
- Modify Vue ProjectList component to display actual domains from latest URLs
- Add getActualDomain function to extract hostnames from real URLs with fallback
- Enhance tests to validate new latestURL and latestTitle fields in API responses
- Fix SQL query counting issue with multiple bookmarks having same timestamp

Resolves displaying "docs.example.com" placeholder with real bookmark domains.

🤖 Generated with [Claude Code](https://claude.ai/code)