### PR TITLE
Fix edit button functionality and add archive button to share page

### DIFF
--- a/frontend/src/components/share/ShareGroups.vue
+++ b/frontend/src/components/share/ShareGroups.vue
@@ -75,6 +75,7 @@
                 <button class="action-btn preview" @click="previewItem(item)">👁️</button>
                 <button class="action-btn edit" @click="editItem(item)">✏️</button>
                 <button class="action-btn share" @click="shareItem(item)">📤</button>
+                <button class="action-btn archive" @click="archiveItem(item)">📦</button>
               </div>
             </div>
             
@@ -125,6 +126,7 @@ const emit = defineEmits<{
   'preview-item': [item: Bookmark]
   'edit-item': [item: Bookmark]
   'share-item': [item: Bookmark]
+  'archive-item': [item: Bookmark]
 }>()
 
 // Copy functionality - use fallback method that works reliably
@@ -271,6 +273,10 @@ const editItem = (item: Bookmark) => {
 
 const shareItem = (item: Bookmark) => {
   emit('share-item', item)
+}
+
+const archiveItem = (item: Bookmark) => {
+  emit('archive-item', item)
 }
 
 const copyGroupItems = async (group: ShareGroup, format: string) => {
@@ -541,6 +547,11 @@ const getItemPreview = (item: Bookmark, format: string): string => {
 .action-btn.share {
   background: #c6f6d5;
   color: #22543d;
+}
+
+.action-btn.archive {
+  background: #fed7d7;
+  color: #742a2a;
 }
 
 /* Share Formats */

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -127,7 +127,13 @@
               </div>
             </div>
             <div class="section-content">
-              <ShareGroups :groups="shareGroups" />
+              <ShareGroups 
+                :groups="shareGroups" 
+                @edit-item="(item) => handleEdit(item.id)"
+                @archive-item="(item) => moveBookmarks([item.id], 'archived')"
+                @preview-item="handlePreviewItem"
+                @share-item="(item) => handleShareSingle(item.id)"
+              />
             </div>
           </div>
 
@@ -561,6 +567,12 @@ const handleCancelConfirm = () => {
 const moveSelectedTo = (action: string) => {
   const selectedIds = Array.from(selectedItems.value)
   moveBookmarks(selectedIds, action)
+}
+
+const handlePreviewItem = (item: Bookmark) => {
+  // For now, just open the URL in a new tab
+  // This could be enhanced with a modal preview in the future
+  window.open(item.url, '_blank')
 }
 
 // Lifecycle


### PR DESCRIPTION
- Wire up missing @edit-item event handler in Dashboard.vue for ShareGroups component
- Add archive button to individual bookmark items in share page
- Add archiveItem event handler and emit in ShareGroups.vue
- Add handlePreviewItem function for opening bookmarks in new tab
- Style archive button with distinctive red background color

🤖 Generated with [Claude Code](https://claude.ai/code)