### PR TITLE
Fix npm cache dependency path issues in GitHub Actions workflows

### DIFF
--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -14,9 +14,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./extension
     
     steps:
     - uses: actions/checkout@v4
@@ -30,6 +27,7 @@ jobs:
     
     - name: Install dependencies
       run: npm ci
+      working-directory: ./extension
     
     - name: Validate manifest
       run: |
@@ -41,6 +39,7 @@ jobs:
           }
           console.log('Manifest validation passed');
         "
+      working-directory: ./extension
     
     - name: Lint extension files
       run: |
@@ -51,12 +50,14 @@ jobs:
         test -f popup.js || (echo "popup.js missing" && exit 1)
         test -f background.js || (echo "background.js missing" && exit 1)
         echo "All required files present"
+      working-directory: ./extension
     
     - name: Build extension
       run: |
         mkdir -p build
         cp -r *.js *.html *.json *.png build/
         echo "Extension built successfully"
+      working-directory: ./extension
     
     - name: Upload extension artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -14,9 +14,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./frontend
     
     strategy:
       matrix:
@@ -34,18 +31,23 @@ jobs:
     
     - name: Install dependencies
       run: npm ci
+      working-directory: ./frontend
     
     - name: Run linting
       run: npm run lint
+      working-directory: ./frontend
     
     - name: Run type checking
       run: npm run type-check
+      working-directory: ./frontend
     
     - name: Run tests
       run: npm run test:run
+      working-directory: ./frontend
     
     - name: Build for production
       run: npm run build
+      working-directory: ./frontend
     
     - name: Upload build artifacts
       if: matrix.node-version == '20'
@@ -61,3 +63,4 @@ jobs:
         echo "Checking build output size..."
         du -sh dist/
         find dist/ -name "*.js" -exec ls -lh {} \;
+      working-directory: ./frontend


### PR DESCRIPTION
- Remove default working-directory from job level in frontend and extension workflows
- Add explicit working-directory to each step that needs it
- Ensure actions/setup-node can properly resolve cache dependency paths
- Fix "Some specified paths were not resolved, unable to cache dependencies" error

The setup-node action runs before the default working directory is applied, causing cache path resolution to fail. This change makes the path resolution explicit and consistent across both workflows.

Fixes GitHub Actions cache setup for both frontend and extension builds.

🤖 Generated with [Claude Code](https://claude.ai/code)