### PR TITLE
Fix Safari button visibility issue with notifications

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -5,9 +5,13 @@
     <style>
         body {
             width: 300px;
+            min-height: 400px;
+            max-height: 600px;
             padding: 16px;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             font-size: 14px;
+            box-sizing: border-box;
+            overflow-y: auto;
         }
         
         h1 {
@@ -44,7 +48,11 @@
         .button-group {
             display: flex;
             gap: 8px;
-            margin-bottom: 12px;
+            margin: 16px 0 0 0;
+            position: sticky;
+            bottom: 0;
+            background: white;
+            padding: 8px 0;
         }
         
         button {
@@ -76,7 +84,7 @@
         }
         
         .status {
-            margin-top: 12px;
+            margin: 0 0 12px 0;
             padding: 8px;
             border-radius: 4px;
             font-size: 12px;
@@ -99,6 +107,19 @@
             background: #d1ecf1;
             color: #0c5460;
             border: 1px solid #bee5eb;
+        }
+        
+        /* Safari-specific fixes */
+        @supports (-webkit-appearance: none) {
+            body {
+                min-height: auto;
+                height: auto;
+            }
+            
+            .button-group {
+                position: relative;
+                margin-top: 16px;
+            }
         }
         
         .conditional-field {


### PR DESCRIPTION
- Add min/max height constraints and overflow handling for popup body
- Change status margin from top to bottom to prevent layout issues
- Make button group sticky/fixed to ensure always visible
- Add Safari-specific CSS fixes using @supports for webkit
- Prevent buttons from being pushed off-screen when notifications appear

🤖 Generated with [Claude Code](https://claude.ai/code)