### PR TITLE
Remove LIMIT 10 from project statistics endpoints

### DIFF
--- a/main.go
+++ b/main.go
@@ -1166,7 +1166,6 @@ func getProjectStats() ([]ProjectStat, error) {
 				AND (b.deleted = FALSE OR b.deleted IS NULL)
 			)
 		ORDER BY stats.lastUpdated DESC
-		LIMIT 10
 	`
 	
 	rows, err := db.Query(querySQL)
@@ -2366,7 +2365,6 @@ func getReferenceCollections() ([]ReferenceCollection, error) {
 		)
 		GROUP BY topic
 		ORDER BY COUNT(*) DESC, MAX(timestamp) DESC
-		LIMIT 10
 	`
 	
 	rows, err := db.Query(querySQL)


### PR DESCRIPTION
Remove artificial limit of 10 projects from both getProjectStats() and getReferenceCollections() functions to allow users to see all projects in the dashboard. This fixes the issue where only 10 projects were displayed when there were actually 18+ projects in the database.

- Remove LIMIT 10 from getProjectStats() SQL query (line 1169)
- Remove LIMIT 10 from getReferenceCollections() SQL query (line 2368)
- API now returns all projects without artificial pagination limits

🤖 Generated with [Claude Code](https://claude.ai/code)