### PR TITLE
ci(frontend): drop EOL Node 18, add Node 24

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -17,7 +17,7 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
     
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Drop Node 18 from the frontend test matrix (EOL April 2025) and add Node 24 (current LTS)
- Unblocks Dependabot PRs #99 (vite 8), #100 (jsdom 29), #101 (@vitejs/plugin-vue 6) which all rely on Node 20+ APIs

## Why
The three open frontend Dependabot PRs all fail only on the Node 18 matrix entry, with fail-fast cancelling the Node 20/22 runs:
- `@vitejs/plugin-vue@6` calls `crypto.hash()` (Node 20+)
- `jsdom@29` ships ESM modules `require()`-d by transitive deps (resolution differs in Node 20+)
- `vite@8` needs `@vitejs/plugin-vue@6` (peer dep)

## Test plan
- [ ] CI matrix runs on Node 20, 22, 24
- [ ] Trigger Dependabot rebase on #99/#100/#101; merge as they go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)